### PR TITLE
1.20.1 Updated Barrel Blockstates and Model Generator

### DIFF
--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/aspen_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/aspen_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/aspen_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/aspen_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/aspen_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/baobab_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/baobab_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/baobab_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/baobab_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/baobab_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/blue_enchanted_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/blue_enchanted_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/blue_enchanted_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/blue_enchanted_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/blue_enchanted_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/cika_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/cika_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/cika_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/cika_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/cika_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/cypress_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/cypress_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/cypress_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/cypress_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/cypress_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/ebony_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/ebony_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/ebony_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/ebony_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/ebony_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/fir_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/fir_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/fir_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/fir_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/fir_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/florus_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/florus_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/florus_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/florus_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/florus_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/green_enchanted_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/green_enchanted_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/green_enchanted_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/green_enchanted_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/green_enchanted_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/holly_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/holly_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/holly_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/holly_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/holly_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/ironwood_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/ironwood_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/ironwood_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/ironwood_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/ironwood_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/jacaranda_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/jacaranda_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/jacaranda_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/jacaranda_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/jacaranda_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/mahogany_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/mahogany_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/mahogany_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/mahogany_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/mahogany_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/maple_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/maple_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/maple_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/maple_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/maple_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/palm_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/palm_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/palm_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/palm_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/palm_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/pine_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/pine_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/pine_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/pine_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/pine_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/rainbow_eucalyptus_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/rainbow_eucalyptus_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/rainbow_eucalyptus_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/rainbow_eucalyptus_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/rainbow_eucalyptus_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/redwood_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/redwood_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/redwood_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/redwood_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/redwood_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/sakura_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/sakura_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/sakura_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/sakura_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/sakura_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/skyris_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/skyris_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/skyris_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/skyris_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/skyris_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/white_mangrove_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/white_mangrove_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/white_mangrove_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/white_mangrove_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/white_mangrove_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/willow_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/willow_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/willow_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/willow_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/willow_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/witch_hazel_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/witch_hazel_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/witch_hazel_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/witch_hazel_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/witch_hazel_barrel",

--- a/Common/src/main/generated/resources/assets/woodwevegot/blockstates/zelkova_barrel.json
+++ b/Common/src/main/generated/resources/assets/woodwevegot/blockstates/zelkova_barrel.json
@@ -20,9 +20,11 @@
     },
     "facing=north,open=false": {
       "model": "woodwevegot:block/zelkova_barrel"
+      "x": 90
     },
     "facing=north,open=true": {
       "model": "woodwevegot:block/zelkova_barrel_open"
+      "x": 90
     },
     "facing=south,open=false": {
       "model": "woodwevegot:block/zelkova_barrel",

--- a/Forge/src/main/java/net/potionstudios/woodwevegot/forge/datagen/generators/ModelGenerators.java
+++ b/Forge/src/main/java/net/potionstudios/woodwevegot/forge/datagen/generators/ModelGenerators.java
@@ -59,6 +59,7 @@ public class ModelGenerators {
                             current = open;
                         return switch (blockState.getValue(BarrelBlock.FACING)) {
                             case DOWN -> ConfiguredModel.builder().modelFile(current).rotationX(180).build();
+                            case NORTH -> ConfiguredModel.builder().modelFile(current).rotationX(90).build();
                             case EAST -> ConfiguredModel.builder().modelFile(current).rotationY(90).rotationX(90).build();
                             case SOUTH -> ConfiguredModel.builder().modelFile(current).rotationX(90).rotationY(180).build();
                             case WEST -> ConfiguredModel.builder().modelFile(current).rotationY(270).rotationX(90).build();


### PR DESCRIPTION
(Almost identical to 1.21.1 request)

"facing=north" barrels were missing a rotation of 90 on the x axis, making them impossible to place in one orientation when facing that direction. I updated the generator in the Fabric folder & the individual blockstate files in the common folder.